### PR TITLE
Add functionality to write to laravel.log

### DIFF
--- a/src/QueryBuilderDumpServiceProvider.php
+++ b/src/QueryBuilderDumpServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Morrislaptop\QueryBuilderDump;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class QueryBuilderDumpServiceProvider extends ServiceProvider
@@ -20,12 +21,14 @@ class QueryBuilderDumpServiceProvider extends ServiceProvider
             return $sql;
         };
 
-        Builder::macro('dump', function ($dumper = 'dump') use ($raw) {
-            $dumper([
+        Builder::macro('dump', function ($inLine = true, $dumper = 'dump') use ($raw) {
+            $sqlDump = [
                 'bindings' => $this->bindings,
                 'sql' => $this->toSql(),
                 'raw' => $raw($this->toSql(), $this->bindings),
-            ]);
+            ];
+
+            $inLine ? $dumper($sqlDump) : Log::debug($sqlDump);
 
             return $this;
         });


### PR DESCRIPTION
When debugging queries in a staging/production environment, you don't want the query to be shown in line to users. This PR makes it possible to dump the query to the laravel.log